### PR TITLE
Allow a way to export private key info / packaging fixes

### DIFF
--- a/claimchain/crypto/params.py
+++ b/claimchain/crypto/params.py
@@ -53,10 +53,18 @@ class LocalParams(object):
         )
 
     def public_export(self):
+        return self._export(private=False)
+
+    def private_export(self):
+        return self._export(private=True)
+
+    def _export(self, private=False):
         result = {}
         for name, attr in asdict(self, recurse=False).items():
             if isinstance(attr, Keypair):
                 result[name + '_pk'] = pet2ascii(attr.pk)
+                if private:
+                    result[name + '_sk'] = pet2ascii(attr.sk)
         return result
 
     @staticmethod

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,6 @@ future==0.16.0
 -e git+https://github.com/gdanezis/rousseau-chain@dc3cf26bc0281e9b01352316da2e655b0ed84f45#egg=hippiehug&subdirectory=hippiehug-package
 msgpack-python==0.5.4
 petlib==0.0.43
-pkg-resources==0.0.0
 pluggy==0.6.0
 py==1.5.2
 pycparser==2.18

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='claimchain',
-    version='0.1.2',
-    packages=['claimchain',],
+    version='0.1.3',
+    packages=["claimchain", "claimchain.crypto", "claimchain.utils"],
     license='MIT',
     description='Core and experimental implementation of ClaimChain, decentralized PKI',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='claimchain',
-    version='0.1.1',
+    version='0.1.2',
     packages=['claimchain',],
     license='MIT',
     description='Core and experimental implementation of ClaimChain, decentralized PKI',

--- a/tests/crypto/test_params.py
+++ b/tests/crypto/test_params.py
@@ -15,6 +15,9 @@ def test_local_params_public_export(local_params):
     G = PublicParams.get_default().ec_group
     exported = local_params.public_export()
 
+    for key in exported:
+        assert not key.endswith("_sk")
+
     local_params1 = LocalParams.from_dict(exported)
 
     assert local_params1.vrf.pk == local_params.vrf.pk
@@ -26,3 +29,17 @@ def test_local_params_public_export(local_params):
     assert local_params1.dh.sk is None
     assert local_params1.rescue.sk is None
 
+
+def test_local_params_private_export(local_params):
+    G = PublicParams.get_default().ec_group
+    public_exported = local_params.public_export()
+    private_exported = local_params.private_export()
+
+    assert public_exported != private_exported
+    for key, val in public_exported.items():
+        assert private_exported[key] == val
+
+    local_params1 = LocalParams.from_dict(private_exported)
+
+    assert local_params1.vrf.sk == local_params.vrf.sk
+    assert local_params1.sig.sk == local_params.sig.sk


### PR DESCRIPTION
in https://github.com/nextleap-project/muacryptcc we need to persist private key information once it is generated.  We added a flag that allows to do that. 

also a fix for packaging where some subdirs were not included in the dist. 