### PR TITLE
fix the fix for the fix

### DIFF
--- a/claimchain/core.py
+++ b/claimchain/core.py
@@ -39,7 +39,7 @@ def _salt_label(nonce, claim_label):
 # TODO: Remove. Temporary fix for gdanezis/petlib#16
 from petlib.bindings import _FFI
 def _fix_bytes(tag):
-    return _FFI.string(tag)
+    return bytes(_FFI.buffer(tag)[:])
 
 
 @profiled


### PR DESCRIPTION
I had changed the end of encode_capability in claimchain/core.py to this:

```
        enc_body, tag = cipher.quick_gcm_enc(
                enc_key, b"\x00"*pp.enc_key_size, vrf_value)
        assert tag
        fixed_tag = _fix_bytes(tag)
        assert fixed_tag
        return lookup_key, encode([enc_body, fixed_tag])
```

This lead to an AssertionError in the second assert.

Debugging this showed that `_FFI.string` is not the same as
the fix for gdanezis/petlib#16:

```
> /home/azul/code/claimchain-core/claimchain/core.py(117)encode_capability()
(Pdb) p tag
<cdata 'unsigned char[]' owning 16 bytes>
(Pdb) p _fix_bytes(tag)
''
(Pdb) tag
<cdata 'unsigned char[]' owning 16 bytes>
(Pdb) _FFI.string(tag)
''
(Pdb) bytes(_FFI.buffer(tag)[:])
'\x00\xa1\xed\x941\xeb\xc9\xe1?Q\x94\nr\x9e\x0cu'
```

So i used the code from the pe6tlib fix instead.